### PR TITLE
removed relTriTri from dyntri class

### DIFF
--- a/examples_glfwold/201_DynTri2dTriangulation/main.cpp
+++ b/examples_glfwold/201_DynTri2dTriangulation/main.cpp
@@ -176,8 +176,6 @@ void drawMesh
   
 }
 
-
-
 // --------------------------------
 
 std::vector<dfm2::CDynPntSur> aPo2D;
@@ -190,10 +188,10 @@ bool is_animation = true;
 void GenMesh(){
   std::vector<double> aCV0; MakeRandomCV(8,aCV0); // current cv
   std::vector<double> aVecCurve0;  MakeCurveSpline(aCV0,aVecCurve0); // current curve
-  ////
+  //
   std::vector< std::vector<double> > aaXY;
   aaXY.push_back( aVecCurve0 );
-  /////
+  //
   const double elen = 0.03;
   {
     JArray_FromVecVec_XY(loopIP_ind,loopIP, aVec2,
@@ -210,12 +208,18 @@ void GenMesh(){
   }
   Meshing_SingleConnectedShape2D(aPo2D, aVec2, aETri,
                                  loopIP_ind,loopIP);
+  AssertDTri(aETri);
+  AssertMeshDTri(aPo2D,aETri);
+  CheckTri(aPo2D,aETri,aVec2);
   if( elen > 1.0e-10 ){
     dfm2::CInputTriangulation_Uniform param(1.0);
     std::vector<int> aFlgPnt(aPo2D.size()), aFlgTri(aETri.size());
     MeshingInside(aPo2D,aETri,aVec2, aFlgPnt,aFlgTri,
                   aVec2.size(), 0, elen, param);
   }
+  AssertDTri(aETri);
+  AssertMeshDTri(aPo2D,aETri);
+  CheckTri(aPo2D,aETri,aVec2);
 }
 
 // --------------------------------------
@@ -230,8 +234,7 @@ void myGlutDisplay()
   delfem2::opengl::DrawMeshDynTri_Edge(aETri, aVec2);
   ::glColor3d(0.8, 0.8, 0.8);
   delfem2::opengl::DrawMeshDynTri_FaceNorm(aETri, aVec2);
-  
-  
+    
   ::glLineWidth(3);
   ::glColor3d(0,0,0);
   for(int iloop=0;iloop<(int)loopIP_ind.size()-1;iloop++){
@@ -249,21 +252,12 @@ int main(int argc,char* argv[])
 {
   delfem2::opengl::CViewer_GLFW viewer;
   viewer.Init_oldGL();
-  
   while (!glfwWindowShouldClose(viewer.window))
   {
-    {
-      static int iframe = 0;
-      if( iframe == 0 ){
-        GenMesh();
-      }
-      iframe = (iframe + 1)%300;
-    }
-    
+    GenMesh();
+    // ---------
     viewer.DrawBegin_oldGL();
-    
     myGlutDisplay();
-    
     glfwSwapBuffers(viewer.window);
     glfwPollEvents();
   }

--- a/examples_glfwold/202_DynTri2dRemesh/main.cpp
+++ b/examples_glfwold/202_DynTri2dRemesh/main.cpp
@@ -38,12 +38,12 @@ void Coarse(double px, double py)
   for(int ip=(int)aPo2D.size()-1;ip>=0;--ip){
     if( aPo2D[ip].e == -1 ){ continue; }
     if( Distance(aVec2[ip],dfm2::CVec2d(px,py)) > 0.1 ){ continue; }
-    std::vector< std::pair<int,int> > aTriSuP;
+    std::vector< std::pair<unsigned int,unsigned int> > aTriSuP;
     GetTriArrayAroundPoint(aTriSuP,
                            ip,aPo2D,aETri);
     std::vector<int> aPSuP(aTriSuP.size());
-    const int npsup = aPSuP.size();
-    for(int iit=0;iit<npsup;++iit){
+    const unsigned int npsup = aPSuP.size();
+    for(unsigned int iit=0;iit<npsup;++iit){
       const int itri0 = aTriSuP[iit].first;
       const int inotri0 = aTriSuP[iit].second;
       assert( ip == aETri[itri0].v[inotri0] );
@@ -71,7 +71,7 @@ void Coarse(double px, double py)
       if( dist0 < 0.05 ){
         const int itri0 = aTriSuP[iit0].first;
         const int inotri0 = aTriSuP[iit0].second;
-        Collapse_ElemEdge(itri0, (inotri0+1)%3, aPo2D, aETri);
+        CollapseElemEdge(itri0, (inotri0+1)%3, aPo2D, aETri);
         const int ip1 = aETri[itri0].v[ (inotri0+2)%3 ];
         DelaunayAroundPoint(ip1, aPo2D, aETri, aVec2);
       }
@@ -103,7 +103,6 @@ void GenMesh()
                      elen );
     }
   }
-  ////
   Meshing_SingleConnectedShape2D(aPo2D, aVec2, aETri,
                                  loopIP_ind,loopIP);
   if( elen > 1.0e-10 ){
@@ -120,12 +119,9 @@ void myGlutDisplay()
   ::glLineWidth(1);
   ::glPointSize(5);
   ::glColor3d(1,1,0);
-  
   delfem2::opengl::DrawMeshDynTri_Edge(aETri, aVec2);
   ::glColor3d(0.8, 0.8, 0.8);
   delfem2::opengl::DrawMeshDynTri_FaceNorm(aETri, aVec2);
-  
-  
   ::glLineWidth(3);
   ::glColor3d(0,0,0);
   for(int iloop=0;iloop<(int)loopIP_ind.size()-1;iloop++){
@@ -152,17 +148,19 @@ int main(int argc,char* argv[])
       if( iframe == 0 ){
         GenMesh();
       }
-      if( iframe % 100 == 0 ){
+      else{
         double px = (rand()/(RAND_MAX+1.0))-0.5;
         double py = (rand()/(RAND_MAX+1.0))-0.5;
-        if( iframe < 2000 ){
+        if( iframe < 40 ){
+          std::cout << "hoge" << std::endl;
           Refine(px, py);
+          std::cout << "huga" << std::endl;
         }
         else{
           Coarse(px, py);
         }
       }
-      iframe = (iframe + 1)%4000;
+      iframe = (iframe + 1)%40;
     }
     // ----------
     viewer.DrawBegin_oldGL();

--- a/examples_glfwold/205_DynTri3SimpilfyQuadratic/CMakeLists.txt
+++ b/examples_glfwold/205_DynTri3SimpilfyQuadratic/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 2.8)
+
+option(USE_HEADERONLY "USE_DFM2_HEADERONLY" OFF)
+
+######################################################
+
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+IF(MSVC)
+  set(CMAKE_CXX_FLAGS "/W4 -O2 \
+    /wd4100 /wd4458 /wd4577 /wd4267 /wd4244 /wd4505 /wd4838 \
+    /wd4800 /wd4996 /wd4530 /wd4245 /wd4505 /wd4505 /wd4456 ")
+ELSE()
+  set(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated-declarations -g")
+ENDIF()
+
+####################################
+
+project(205_DynTri3SimplifyQuadratic)
+
+add_definitions(-DPATH_INPUT_DIR="${PROJECT_SOURCE_DIR}/../../test_inputs")
+
+# glfw
+IF(MSVC)
+  set(GLFW_LIBRARY    ../../3rd_party/glfw/src/Release/glfw3.lib)
+ELSE()
+  set(GLFW_LIBRARY    ../../3rd_party/glfw/src/libglfw3.a)
+ENDIF()
+get_filename_component(GLFW_LIBRARY ${GLFW_LIBRARY} ABSOLUTE)
+get_filename_component(GLFW_INCLUDE_DIR ../../3rd_party/glfw/include ABSOLUTE)
+
+# opengl
+find_package(OpenGL REQUIRED)
+
+# dfm2
+IF(USE_HEADERONLY)
+  add_definitions(-DDFM2_HEADER_ONLY=ON)            
+else()
+  if(MSVC)
+    set(DFM2_LIBRARY
+      ${PROJECT_SOURCE_DIR}/../dfm2_static_glfwold/dfm2_static_glfwold.lib )
+  else()
+    set(DFM2_LIBRARY
+      ${PROJECT_SOURCE_DIR}/../dfm2_static_glfwold/libdfm2_static_glfwold.a )
+  endif()
+ENDIF()
+set(DELFEM2_INCLUDE_DIR "../../include")
+
+#########################################
+
+include_directories(
+  ${OPENGL_INCLUDE_DIR}
+  ${GLFW_INCLUDE_DIR}
+  ${DELFEM2_INCLUDE_DIR}
+)
+
+add_executable(${PROJECT_NAME}
+  main.cpp
+)
+
+#########################################
+
+IF(APPLE)
+  find_library( COCOA_LIBRARY Cocoa )
+  find_library( IOKIT_LIBRARY IOKit )
+  find_library( COREVIDEO_LIBRARY CoreVideo )
+  target_link_libraries(${PROJECT_NAME}
+    ${DFM2_LIBRARY}
+    ${OPENGL_LIBRARY}
+    ${GLFW_LIBRARY}
+    ${COCOA_LIBRARY}
+    ${IOKIT_LIBRARY}
+    ${COREVIDEO_LIBRARY}
+  )
+ELSEIF(UNIX)
+  target_link_libraries(${PROJECT_NAME}
+    ${DFM2_LIBRARY}
+    ${OPENGL_LIBRARY}
+    ${GLFW_LIBRARY}
+    -lrt -lm -ldl -lX11 -lpthread -lxcb -lXau -lXdmcp
+  )  
+ELSEIF(MSVC)
+  target_link_libraries(${PROJECT_NAME}
+    ${DFM2_LIBRARY} 
+    ${GLFW_LIBRARY}
+    ${OPENGL_LIBRARY}
+  )
+ENDIF()

--- a/examples_glfwold/205_DynTri3SimpilfyQuadratic/main.cpp
+++ b/examples_glfwold/205_DynTri3SimpilfyQuadratic/main.cpp
@@ -9,11 +9,13 @@
 #include <string>
 #include <cassert>
 #include <cstdlib>
+#include "delfem2/geo3_v23m34q.h"
+#include "delfem2/dtri3_v3dtri.h"
 #include "delfem2/mshmisc.h"
 #include "delfem2/mshio.h"
-#include "delfem2/dtri3_v3dtri.h"
 
 #include <GLFW/glfw3.h>
+#include "delfem2/opengl/funcs_glold.h"
 #include "delfem2/opengl/v3q_glold.h"
 #include "delfem2/opengl/glfw/viewer_glfw.h"
 
@@ -73,10 +75,63 @@ void myGlutDisplay
   if(  is_texture  ){ ::glEnable(GL_TEXTURE_2D); }
 }
 
+double MinimizeQuad(double* pos,
+                    const double* SymMat4_Q)
+{
+  const dfm2::CMat3d A(SymMat4_Q[0], SymMat4_Q[1], SymMat4_Q[2],
+                       SymMat4_Q[1], SymMat4_Q[4], SymMat4_Q[5],
+                       SymMat4_Q[2], SymMat4_Q[5], SymMat4_Q[7]);
+  const dfm2::CVec3d v(SymMat4_Q[3], SymMat4_Q[6], SymMat4_Q[8]);
+  const dfm2::CVec3d p = -A.Inverse()*v;
+  p.CopyTo(pos);
+  return SymMat4_Q[9] + p*v;
+//  std::cout << ip << " ###  " << aVec3[ip] << "  ###  " << p - aVec3[ip] << " ### " << err << std::endl;
+}
+
+
+void QuadMetric
+ (std::vector<double>& aSymMat4,
+  std::vector<dfm2::CDynPntSur>& aDP,
+  std::vector<dfm2::CDynTri>& aDTri,
+  std::vector<dfm2::CVec3d>& aVec3)
+{
+  const unsigned int np = aDP.size();
+  aSymMat4.assign(np*10, 0.0);
+  for(unsigned int ip=0;ip<np;++ip){
+    std::vector< std::pair<unsigned int,unsigned int> > aTriSurPo;
+    dfm2::GetTriArrayAroundPoint(aTriSurPo,
+                                 ip,aDP,aDTri);
+    for(unsigned iit=0;iit<aTriSurPo.size();++iit){
+      unsigned int it0 = aTriSurPo[iit].first;
+      unsigned int ino0 = aTriSurPo[iit].second;
+      assert( aDTri[it0].v[ino0] == ip );
+      const dfm2::CVec3d n0 = dfm2::UnitNormal_DTri3(it0, aDTri, aVec3);
+      const double a0 = n0.x();
+      const double b0 = n0.y();
+      const double c0 = n0.z();
+      const double d0 = -n0*aVec3[ip];
+      aSymMat4[ip*10+0] += a0*a0;
+      aSymMat4[ip*10+1] += a0*b0;
+      aSymMat4[ip*10+2] += a0*c0;
+      aSymMat4[ip*10+3] += a0*d0;
+      aSymMat4[ip*10+4] += b0*b0;
+      aSymMat4[ip*10+5] += b0*c0;
+      aSymMat4[ip*10+6] += b0*d0;
+      aSymMat4[ip*10+7] += c0*c0;
+      aSymMat4[ip*10+8] += c0*d0;
+      aSymMat4[ip*10+9] += d0*d0;
+    }
+    double pos[3];
+    double err = MinimizeQuad(pos, aSymMat4.data()+ip*10);
+    std::cout << ip << " ### " << err << " ### " << dfm2::CVec3d(pos)-aVec3[ip] << std::endl;
+  }
+  
+}
+
 int main(int argc,char* argv[])
 {
-  std::vector<dfm2::CDynPntSur> aPo;
-  std::vector<dfm2::CDynTri> aTri;
+  std::vector<dfm2::CDynPntSur> aDP;
+  std::vector<dfm2::CDynTri> aDTri;
   std::vector<dfm2::CVec3d> aVec3;
   {
     std::vector<double> aXYZ0;
@@ -85,19 +140,24 @@ int main(int argc,char* argv[])
                       aXYZ0,aTri0);
     dfm2::Normalize_Points3(aXYZ0,2.0);
     const unsigned int np = aXYZ0.size()/3;
-    aPo.resize(np);
+    aDP.resize(np);
     aVec3.resize(np);
-    for(unsigned int ipo=0;ipo<aPo.size();ipo++){
+    for(unsigned int ipo=0;ipo<aDP.size();ipo++){
       aVec3[ipo].p[0] = aXYZ0[ipo*3+0];
       aVec3[ipo].p[1] = aXYZ0[ipo*3+1];
       aVec3[ipo].p[2] = aXYZ0[ipo*3+2];
     }
-    InitializeMesh(aPo, aTri,
+    InitializeMesh(aDP, aDTri,
                    aTri0.data(),aTri0.size()/3,aVec3.size());
-    AssertDTri(aTri);
-    AssertMeshDTri(aPo, aTri);
-    AssertMeshDTri2(aPo, aTri, aVec3);
+#if !defined(NDEBUG)
+    AssertDTri(aDTri);
+    AssertMeshDTri(aDP, aDTri);
+    AssertMeshDTri2(aDP, aDTri, aVec3);
+#endif
   }
+  std::vector<double> aSymMat4;
+  QuadMetric(aSymMat4,
+             aDP,aDTri,aVec3);
   // -----------
   delfem2::opengl::CViewer_GLFW viewer;
   viewer.Init_oldGL();
@@ -105,15 +165,20 @@ int main(int argc,char* argv[])
   while (!glfwWindowShouldClose(viewer.window))
   {
     for(unsigned int i=0;i<10;i++){
-      auto itri0 = (unsigned int)((rand()/(RAND_MAX+1.0))*aTri.size());
-      assert( itri0 < aTri.size() );
-      CollapseElemEdge(itri0, 0, aPo, aTri);
-      AssertDTri(aTri);
-      AssertMeshDTri(aPo, aTri);
-      if( aTri.size() <= 100 ) break;
+      auto itri0 = (unsigned int)((rand()/(RAND_MAX+1.0))*aDTri.size());
+      assert( itri0 < aDTri.size() );
+      const int ip_del = aDTri[itri0].v[2];
+      bool res = CollapseElemEdge(itri0, 0, aDP, aDTri);
+#if !defined(NDEBUG)
+      if( res ){
+        assert( aDP[ip_del].e == -1 );
+      }
+      AssertMeshDTri(aDP, aDTri);
+#endif
+      if( aDTri.size() <= 100 ) break;
     }
     viewer.DrawBegin_oldGL();
-    myGlutDisplay(aPo,aTri,aVec3);
+    myGlutDisplay(aDP,aDTri,aVec3);
     viewer.DrawEnd_oldGL();
   }
   glfwDestroyWindow(viewer.window);

--- a/examples_glfwold/CMakeLists.txt
+++ b/examples_glfwold/CMakeLists.txt
@@ -39,11 +39,12 @@ add_subdirectory(122_HashBvhSelfCollision)
 add_subdirectory(123_HashLbvh3D)
 add_subdirectory(124_4RotSymField)
 
-# meshing
+# dynamic meshing
 add_subdirectory(201_DynTri2dTriangulation)
 add_subdirectory(202_DynTri2dRemesh)
 add_subdirectory(203_DynTri3dEdgeCollapses)
 add_subdirectory(204_DynTetTetrahedralization)
+add_subdirectory(205_DynTri3SimpilfyQuadratic)
 
 # rigging
 add_subdirectory(300_RigSmplArticulated)

--- a/include/delfem2/dtri.h
+++ b/include/delfem2/dtri.h
@@ -16,6 +16,7 @@
 
 namespace delfem2 {
 
+/*
 // (6-i-j)%3;
 static const unsigned int relTriTri[3][3] = {
 	{ 0, 2, 1 }, //  0
@@ -23,12 +24,13 @@ static const unsigned int relTriTri[3][3] = {
 	{ 1, 0, 2 }, //  2
 };
 static const unsigned int invRelTriTri[3] = { 0, 1, 2 };
+ */
 
 class CDynTri{
 public:
 	int v[3];	//!< index of vertex
 	int s2[3];	//!< index of face that is adjacent to ith edge; The 0th edge is the edge facing 0th vertex
-  int r2[3];	//!< relationship of vertex index between two adjacent faces
+//  int r2[3];	//!< relationship of vertex index between two adjacent faces
 };
 
 class CDynPntSur{
@@ -42,6 +44,11 @@ public:
   int e;  //<! index of elements this can be zero
   unsigned int d;
 };
+
+DFM2_INLINE unsigned int FindAdjEdgeIndex
+(const CDynTri& t0,
+ unsigned int ied0,
+ const std::vector<delfem2::CDynTri>& aTri);
 
 DFM2_INLINE bool JArray_MakeElSuP
  (std::vector<int>& elsup_ind, std::vector<int>& elsup,
@@ -62,13 +69,12 @@ DFM2_INLINE void JArray_PSuP
   const std::vector<CDynTri>& aTri, const unsigned int npoin,
   const std::vector<int>& elsup_ind, const std::vector<int>& elsup);
 
-DFM2_INLINE bool CheckTri
+DFM2_INLINE void AssertDTri
  (const std::vector<CDynTri>& aETri);
 
-DFM2_INLINE bool CheckTri
+DFM2_INLINE void AssertMeshDTri
  (const std::vector<CDynPntSur>& aEPo2,
-  const std::vector<CDynTri>& aETri,
-  bool is_assert=true);
+  const std::vector<CDynTri>& aETri);
 
 DFM2_INLINE void InitializeMesh
  (std::vector<CDynPntSur>& aEPo2,
@@ -92,8 +98,8 @@ DFM2_INLINE bool FindEdge_LookAllTriangles
   const std::vector<CDynTri>& aETri);
 
 DFM2_INLINE void GetTriArrayAroundPoint
- (std::vector< std::pair<int,int> >& aTriSurPo,
-  int ipoin,
+ (std::vector< std::pair<unsigned int, unsigned int> >& aTriSurPo,
+  unsigned int ipoin,
   const std::vector<CDynPntSur>& aEPo2,
   const std::vector<CDynTri>& aETri);
 
@@ -102,7 +108,7 @@ DFM2_INLINE void MoveCCW
   unsigned int &inotri_cur,
   bool& flag_is_wall,
   //
-  std::vector<CDynTri>& aTri);
+  const std::vector<CDynTri>& aTri);
 
 // ---------------
 // topology edit
@@ -136,9 +142,12 @@ DFM2_INLINE bool DeleteTri
   std::vector<CDynPntSur>& aEPo2,
   std::vector<CDynTri>& aETri);
 
-DFM2_INLINE bool Collapse_ElemEdge
- (const int itri_del,
-  const int ied_del,
+/**
+ * @brief delete a point aETri[itri_del].v[(ied_del+2)%3]
+ */
+DFM2_INLINE bool CollapseElemEdge
+ (const unsigned int itri_del,
+  const unsigned int ied_del,
   std::vector<CDynPntSur>& aEPo2,
   std::vector<CDynTri>& aETri);
 

--- a/include/delfem2/dtri2_v2dtri.h
+++ b/include/delfem2/dtri2_v2dtri.h
@@ -224,8 +224,8 @@ public:
   }
   void Check()
   {
-    CheckTri(aETri);
-    CheckTri(aEPo, aETri);
+    AssertDTri(aETri);
+    AssertMeshDTri(aEPo, aETri);
     CheckTri(aEPo, aETri, aVec2);
   }
   std::vector<double> MinMax_XYZ() const {
@@ -313,7 +313,7 @@ public:
   }
   int nTri() const { return aETri.size(); }
   int nPoint() const { return aEPo.size(); }
-  void DeleteTriEdge(int itri, int iedge){ Collapse_ElemEdge(itri, iedge, aEPo, aETri); }
+  void DeleteTriEdge(int itri, int iedge){ CollapseElemEdge(itri, iedge, aEPo, aETri); }
 public:
   std::vector<CDynPntSur> aEPo;
   std::vector<CDynTri> aETri;

--- a/include/delfem2/dtri3_v3dtri.cpp
+++ b/include/delfem2/dtri3_v3dtri.cpp
@@ -193,20 +193,20 @@ DFM2_INLINE bool FindRayTriangleMeshIntersectionClosestToPoint
 // --------------------------------------------------------------------------
 // expose functions
 
-delfem2::CVec3d delfem2::normalTri
+delfem2::CVec3d delfem2::UnitNormal_DTri3
 (int itri0,
  const std::vector<CDynTri>& aSTri,
- const std::vector<CVec3d>& aXYZ)
+ const std::vector<CVec3d>& aP3)
 {
   int i0 = aSTri[itri0].v[0];
   int i1 = aSTri[itri0].v[1];
   int i2 = aSTri[itri0].v[2];
-  CVec3d n = Normal(aXYZ[i0], aXYZ[i1], aXYZ[i2]);
+  const CVec3d n = Normal(aP3[i0], aP3[i1], aP3[i2]);
   return n.Normalize();
 }
 
 
-bool delfem2::CheckTri
+bool delfem2::AssertMeshDTri2
 (const std::vector<CDynPntSur>& aPo3D,
  const std::vector<CDynTri>& aSTri,
  const std::vector<CVec3d>& aXYZ)
@@ -281,8 +281,8 @@ bool delfem2::DelaunayAroundPoint
       assert(aTri[itri_cur].v[inotri_cur]==ipo0);
       // check opposing element
       const int itri_dia = aTri[itri_cur].s2[inotri_cur];
-      const unsigned int* rel_dia = relTriTri[aTri[itri_cur].r2[inotri_cur]];
-      const unsigned int inotri_dia = rel_dia[inotri_cur];
+//      const unsigned int* rel_dia = relTriTri[aTri[itri_cur].r2[inotri_cur]];
+      const unsigned int inotri_dia = FindAdjEdgeIndex(aTri[itri_cur],inotri_cur,aTri) ;// rel_dia[inotri_cur];
       assert(aTri[itri_dia].s2[inotri_dia]==itri_cur);
       const int ipo_dia = aTri[itri_dia].v[inotri_dia];
       if (DetDelaunay(aVec3[aTri[itri_cur].v[0]],
@@ -336,8 +336,8 @@ bool delfem2::DelaunayAroundPoint
     if (aTri[itri_cur].s2[inotri_cur]>=0&&aTri[itri_cur].s2[inotri_cur]<(int)aTri.size()){
       // check elements in opposing side
       const int itri_dia = aTri[itri_cur].s2[inotri_cur];
-      const unsigned int* rel_dia = relTriTri[aTri[itri_cur].r2[inotri_cur]];
-      const unsigned int inotri_dia = rel_dia[inotri_cur];
+//      const unsigned int* rel_dia = relTriTri[aTri[itri_cur].r2[inotri_cur]];
+      const unsigned int inotri_dia = FindAdjEdgeIndex(aTri[itri_cur],inotri_cur,aTri); // rel_dia[inotri_cur];
       assert(aTri[itri_dia].s2[inotri_dia]==itri_cur);
       const int ipo_dia = aTri[itri_dia].v[inotri_dia];
       if (DetDelaunay(aVec3[aTri[itri_cur].v[0]],
@@ -359,8 +359,9 @@ bool delfem2::DelaunayAroundPoint
         return true;
       }
       const int itri_nex = aTri[itri_cur].s2[inotri2];
-      const unsigned int* rel_nex = relTriTri[aTri[itri_cur].r2[inotri2]];
-      const unsigned int inotri_nex = rel_nex[inotri_cur];
+//      const unsigned int* rel_nex = relTriTri[aTri[itri_cur].r2[inotri2]];
+      const unsigned int jno0 = FindAdjEdgeIndex(aTri[itri_cur], inotri2, aTri);
+      const unsigned int inotri_nex = (jno0+2)%3;// rel_nex[inotri_cur];
       assert(aTri[itri_nex].v[inotri_nex]==ipo0);
       assert(itri_nex!=itri0);  // finsih if reach starting elemnet
       itri_cur = itri_nex;

--- a/include/delfem2/dtri3_v3dtri.h
+++ b/include/delfem2/dtri3_v3dtri.h
@@ -18,24 +18,28 @@
 
 namespace delfem2 {
 
-CVec3d normalTri(int itri0,
-                   const std::vector<CDynTri>& aSTri,
-                   const std::vector<CVec3d>& aVec3);
+CVec3d UnitNormal_DTri3
+ (int itri0,
+  const std::vector<CDynTri>& aSTri,
+  const std::vector<CVec3d>& aVec3);
 
-bool CheckTri(const std::vector<CDynPntSur>& aPo3D,
-              const std::vector<CDynTri>& aSTri,
-              const std::vector<CVec3d>& aVec3);
+bool AssertMeshDTri2
+ (const std::vector<CDynPntSur>& aPo3D,
+  const std::vector<CDynTri>& aSTri,
+  const std::vector<CVec3d>& aVec3);
 
-bool FindRayTriangleMeshIntersections(std::vector<CVec3d> &intersectionPoints,
-                                      const CVec3d &line0,
-                                      const CVec3d &line1,
-                                      const std::vector<CDynTri>& aTri,
-                                      const std::vector<CVec3d>& aVec3);
+bool FindRayTriangleMeshIntersections
+ (std::vector<CVec3d> &intersectionPoints,
+  const CVec3d &line0,
+  const CVec3d &line1,
+  const std::vector<CDynTri>& aTri,
+  const std::vector<CVec3d>& aVec3);
 
-bool DelaunayAroundPoint(int ipo0,
-                         std::vector<CDynPntSur>& aPo,
-                         std::vector<CDynTri>& aTri,
-                         const std::vector<CVec3d>& aVec3);
+bool DelaunayAroundPoint
+ (int ipo0,
+  std::vector<CDynPntSur>& aPo,
+  std::vector<CDynTri>& aTri,
+  const std::vector<CVec3d>& aVec3);
 
 // -------------------------------------------------------
 
@@ -63,9 +67,9 @@ public:
   }
   void Check()
   {
-    CheckTri(aETri);
-    CheckTri(aEPo, aETri);
-    CheckTri(aEPo, aETri, aVec3);
+    AssertDTri(aETri);
+    AssertMeshDTri(aEPo, aETri);
+    AssertMeshDTri2(aEPo, aETri, aVec3);
   }
   std::vector<double> MinMax_XYZ() const {
     double x_min,x_max, y_min,y_max, z_min,z_max;
@@ -111,7 +115,7 @@ public:
   }
   int nTri() const { return aETri.size(); }
   int nPoint() const { return aEPo.size(); }
-  void DeleteTriEdge(int itri, int iedge){ Collapse_ElemEdge(itri, iedge, aEPo, aETri); }
+  void DeleteTriEdge(int itri, int iedge){ CollapseElemEdge(itri, iedge, aEPo, aETri); }
 public:
   std::vector<CDynPntSur> aEPo;
   std::vector<CDynTri> aETri;

--- a/include/delfem2/mat3.cpp
+++ b/include/delfem2/mat3.cpp
@@ -707,6 +707,15 @@ delfem2::CMat3<T>::CMat3
   T v20, T v21, T v22):
  mat{v00,v01,v02, v10,v11,v12, v20,v21,v22}
 {}
+#ifndef DFM2_HEADER_ONLY
+template delfem2::CMat3<float>::CMat3(float v00, float v01, float v02,
+                                      float v10, float v11, float v12,
+                                      float v20, float v21, float v22);
+template delfem2::CMat3<double>::CMat3(double v00, double v01, double v02,
+                                       double v10, double v11, double v12,
+                                       double v20, double v21, double v22);
+#endif
+
 
 // ----------------------
 

--- a/include/delfem2/objfdtri_objfdtri23.cpp
+++ b/include/delfem2/objfdtri_objfdtri23.cpp
@@ -69,8 +69,8 @@ void delfem2::PBD_Bend
       const int jt0 = aETri[it].s2[ie];
       if( jt0 == -1 ){ continue; }
       if( jt0 > (int)it ){ continue; }
-      const int rt0 = aETri[it].r2[ie];
-      const int je0 = (6-rt0-ie)%3;
+//      const int rt0 = aETri[it].r2[ie];
+      const int je0 = FindAdjEdgeIndex(aETri[jt0],ie,aETri);
       assert( aETri[jt0].s2[je0] == (int)it);
       const int aIP[4] = {
         aETri[it].v[ie],


### PR DESCRIPTION
The dynamic mesh class "CDynTri" was very difficult to handle because it keeps track of the relative orientation to the adjacent elements. I removed that relative orientation member variable to make it simple. The orientation can be found by calling a function "FindAdjEdgeIndex". This might make the program run a bit slow but it is much simpler than before. 